### PR TITLE
Feat: add always-display file count and file info

### DIFF
--- a/app/src/main/java/com/rcmiku/ncm/dumper/navigation/NavGraph.kt
+++ b/app/src/main/java/com/rcmiku/ncm/dumper/navigation/NavGraph.kt
@@ -1,5 +1,6 @@
 package com.rcmiku.ncm.dumper.navigation
 
+import android.net.Uri
 import android.os.Build
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
@@ -8,12 +9,15 @@ import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.navigation.NavHostController
+import androidx.navigation.NavType
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
 import com.google.accompanist.permissions.ExperimentalPermissionsApi
 import com.google.accompanist.permissions.isGranted
 import com.google.accompanist.permissions.rememberPermissionState
 import com.rcmiku.ncm.dumper.ui.NCMDumperApp
+import com.rcmiku.ncm.dumper.ui.screen.FileDescriptionScreen
 import com.rcmiku.ncm.dumper.ui.screen.SettingsScreen
 import com.rcmiku.ncm.dumper.viewModel.NCMDumperViewModel
 
@@ -53,5 +57,19 @@ fun NavGraph(navController: NavHostController, viewModel: NCMDumperViewModel) {
         }) {
         composable(Screen.Home.route) { NCMDumperApp(viewModel, navController) }
         composable(Screen.Settings.route) { SettingsScreen(viewModel, navController) }
+        composable(
+            route = Screen.Description.route + "/{fileId}",
+            arguments = listOf(
+                navArgument("fileId") { type = NavType.IntType },
+            )
+        ) { backStackEntry ->
+            val fileId = backStackEntry.arguments?.getInt("fileId") ?: return@composable
+            val file = viewModel.cacheFileList.value[fileId]
+
+            FileDescriptionScreen(
+                navController = navController,
+                file = file
+            )
+        }
     }
 }

--- a/app/src/main/java/com/rcmiku/ncm/dumper/navigation/Screen.kt
+++ b/app/src/main/java/com/rcmiku/ncm/dumper/navigation/Screen.kt
@@ -3,4 +3,5 @@ package com.rcmiku.ncm.dumper.navigation
 sealed class Screen(val route: String) {
     data object Home : Screen("home")
     data object Settings : Screen("settings")
+    data object Description : Screen("description")
 }

--- a/app/src/main/java/com/rcmiku/ncm/dumper/ui/NCMDumperApp.kt
+++ b/app/src/main/java/com/rcmiku/ncm/dumper/ui/NCMDumperApp.kt
@@ -271,11 +271,14 @@ fun NCMDumperApp(viewModel: NCMDumperViewModel, navController: NavHostController
                                 .padding(bottom = 4.dp)
                         ) {
                             NCMFileItem(ncmFile, onClick = {
-                                if (isSelectMode)
+                                if (isSelectMode) {
                                     viewModel.updateCheckedState(
                                         ncmFile.uri,
                                         !ncmFile.checkState
                                     )
+                                } else {
+                                    navController.navigate(Screen.Description.route + "/${index}")
+                                }
                             }, onLongClick = {
                                 viewModel.updateCheckedState(ncmFile.uri, !ncmFile.checkState)
                             })

--- a/app/src/main/java/com/rcmiku/ncm/dumper/ui/NCMDumperApp.kt
+++ b/app/src/main/java/com/rcmiku/ncm/dumper/ui/NCMDumperApp.kt
@@ -1,26 +1,14 @@
 package com.rcmiku.ncm.dumper.ui
 
 import android.content.Intent
+import android.net.Uri
 import android.os.Environment
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
-import androidx.compose.foundation.layout.WindowInsetsSides
-import androidx.compose.foundation.layout.displayCutout
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.heightIn
-import androidx.compose.foundation.layout.navigationBars
-import androidx.compose.foundation.layout.only
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.foundation.layout.windowInsetsPadding
+import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
 import androidx.compose.foundation.shape.RoundedCornerShape
@@ -28,33 +16,12 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Clear
 import androidx.compose.material.icons.filled.Search
 import androidx.compose.material.icons.filled.Settings
-import androidx.compose.material3.Button
-import androidx.compose.material3.Card
-import androidx.compose.material3.CenterAlignedTopAppBar
-import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FloatingActionButton
-import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Scaffold
-import androidx.compose.material3.SearchBar
-import androidx.compose.material3.SearchBarDefaults
-import androidx.compose.material3.SnackbarHost
-import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.Text
-import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.material3.*
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.material3.pulltorefresh.PullToRefreshDefaults.Indicator
 import androidx.compose.material3.pulltorefresh.rememberPullToRefreshState
-import androidx.compose.material3.rememberTopAppBarState
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.*
 import androidx.compose.runtime.saveable.rememberSaveable
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -277,10 +244,9 @@ fun NCMDumperApp(viewModel: NCMDumperViewModel, navController: NavHostController
 
                         }
                     }
-
-                    AnimatedVisibility(ncmFiles.isNotEmpty()) {
+                    AnimatedVisibility(selectedFolderUri != Uri.EMPTY) {
                         Text(
-                            stringResource(R.string.file_count, ncmFiles.count()),
+                            stringResource(R.string.file_count, ncmFiles.count(), selectedFolderUri.lastPathSegment ?: ""),
                             modifier = Modifier.padding(start = 24.dp, bottom = 12.dp),
                             style = MaterialTheme.typography.titleSmall
                         )

--- a/app/src/main/java/com/rcmiku/ncm/dumper/ui/imageVector/Convert.kt
+++ b/app/src/main/java/com/rcmiku/ncm/dumper/ui/imageVector/Convert.kt
@@ -1,0 +1,46 @@
+package com.rcmiku.ncm.dumper.ui.imageVector
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val Convert: ImageVector
+    get() {
+        if (_Convert != null) {
+            return _Convert!!
+        }
+        _Convert = ImageVector.Builder(
+            name = "Convert",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).apply {
+            path(
+                fill = SolidColor(Color(0x00000000)),
+                stroke = SolidColor(Color(0xFF000000)),
+                strokeLineWidth = 2f,
+                strokeLineCap = StrokeCap.Round,
+                strokeLineJoin = StrokeJoin.Round
+            ) {
+                moveTo(3.0f, 12.0f)
+                arcToRelative(9.0f, 9.0f, 0.0f, true, false, 9.0f, -9.0f)
+                arcToRelative(9.75f, 9.75f, 0.0f, false, false, -6.74f, 2.74f)
+                lineTo(3.0f, 8.0f)
+
+                moveTo(3.0f, 3.0f)
+                verticalLineToRelative(5.0f)
+                horizontalLineToRelative(5.0f)
+                close()
+            }
+        }.build()
+
+        return _Convert!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _Convert: ImageVector? = null

--- a/app/src/main/java/com/rcmiku/ncm/dumper/ui/imageVector/Document.kt
+++ b/app/src/main/java/com/rcmiku/ncm/dumper/ui/imageVector/Document.kt
@@ -1,0 +1,50 @@
+package com.rcmiku.ncm.dumper.ui.imageVector
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val Document: ImageVector
+    get() {
+        if (_Document != null) {
+            return _Document!!
+        }
+        _Document = ImageVector.Builder(
+            name = "Document",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).apply {
+            path(
+                fill = SolidColor(Color(0x00000000)),
+                stroke = SolidColor(Color(0xFF000000)),
+                strokeLineWidth = 2f,
+                strokeLineCap = StrokeCap.Round,
+                strokeLineJoin = StrokeJoin.Round
+            ) {
+                moveTo(15.0f, 2.0f)
+                horizontalLineTo(6.0f)
+                arcToRelative(2.0f, 2.0f, 0.0f, false, false, -2.0f, 2.0f)
+                verticalLineToRelative(16.0f)
+                arcToRelative(2.0f, 2.0f, 0.0f, false, false, 2.0f, 2.0f)
+                horizontalLineToRelative(12.0f)
+                arcToRelative(2.0f, 2.0f, 0.0f, false, false, 2.0f, -2.0f)
+                verticalLineTo(7.0f)
+                moveTo(14.0f, 2.0f)
+                verticalLineToRelative(4.0f)
+                arcToRelative(2.0f, 2.0f, 0.0f, false, false, 2.0f, 2.0f)
+                horizontalLineToRelative(4.0f)
+                close()
+            }
+        }.build()
+
+        return _Document!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _Document: ImageVector? = null

--- a/app/src/main/java/com/rcmiku/ncm/dumper/ui/imageVector/Folder.kt
+++ b/app/src/main/java/com/rcmiku/ncm/dumper/ui/imageVector/Folder.kt
@@ -1,0 +1,53 @@
+package com.rcmiku.ncm.dumper.ui.imageVector
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeCap.Companion.Round
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val Folder: ImageVector
+    get() {
+        if (_Folder != null) {
+            return _Folder!!
+        }
+        _Folder = Builder(name = "Folder", defaultWidth = 24.0.dp, defaultHeight = 24.0.dp,
+            viewportWidth = 24.0f, viewportHeight = 24.0f).apply {
+            path(fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF000000)),
+                strokeLineWidth = 2.0f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType = NonZero
+            ) {
+                moveTo(20.0f, 20.0f)
+                arcToRelative(2.0f, 2.0f, 0.0f, false, false, 2.0f, -2.0f)
+                verticalLineTo(8.0f)
+                arcToRelative(2.0f, 2.0f, 0.0f, false, false, -2.0f, -2.0f)
+                horizontalLineToRelative(-7.9f)
+                arcToRelative(2.0f, 2.0f, 0.0f, false, true, -1.69f, -0.9f)
+                lineTo(9.6f, 3.9f)
+                arcTo(2.0f, 2.0f, 0.0f, false, false, 7.93f, 3.0f)
+                horizontalLineTo(4.0f)
+                arcToRelative(2.0f, 2.0f, 0.0f, false, false, -2.0f, 2.0f)
+                verticalLineToRelative(13.0f)
+                arcToRelative(2.0f, 2.0f, 0.0f, false, false, 2.0f, 2.0f)
+                close()
+            }
+            path(fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF000000)),
+                strokeLineWidth = 2.0f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType = NonZero
+            ) {
+                moveTo(2.0f, 10.0f)
+                horizontalLineToRelative(20.0f)
+            }
+        }
+            .build()
+
+        return _Folder!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _Folder: ImageVector? = null

--- a/app/src/main/java/com/rcmiku/ncm/dumper/ui/imageVector/Ruler.kt
+++ b/app/src/main/java/com/rcmiku/ncm/dumper/ui/imageVector/Ruler.kt
@@ -1,0 +1,70 @@
+package com.rcmiku.ncm.dumper.ui.imageVector
+
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.PathFillType.Companion.NonZero
+import androidx.compose.ui.graphics.SolidColor
+import androidx.compose.ui.graphics.StrokeCap
+import androidx.compose.ui.graphics.StrokeCap.Companion.Round
+import androidx.compose.ui.graphics.StrokeJoin
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.graphics.vector.ImageVector.Builder
+import androidx.compose.ui.graphics.vector.path
+import androidx.compose.ui.unit.dp
+
+val Ruler: ImageVector
+    get() {
+        if (_Ruler != null) {
+            return _Ruler!!
+        }
+        _Ruler = Builder(name = "Ruler", defaultWidth = 24.0.dp, defaultHeight = 24.0.dp,
+            viewportWidth = 24.0f, viewportHeight = 24.0f).apply {
+            path(fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF000000)),
+                strokeLineWidth = 2.0f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType = NonZero
+            ) {
+                moveTo(21.3f, 15.3f)
+                arcToRelative(2.4f, 2.4f, 0.0f, false, true, 0.0f, 3.4f)
+                lineToRelative(-2.6f, 2.6f)
+                arcToRelative(2.4f, 2.4f, 0.0f, false, true, -3.4f, 0.0f)
+                lineTo(2.7f, 8.7f)
+                arcToRelative(2.41f, 2.41f, 0.0f, false, true, 0.0f, -3.4f)
+                lineToRelative(2.6f, -2.6f)
+                arcToRelative(2.41f, 2.41f, 0.0f, false, true, 3.4f, 0.0f)
+                close()
+            }
+            path(fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF000000)),
+                strokeLineWidth = 2.0f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType = NonZero
+            ) {
+                moveToRelative(14.5f, 12.5f)
+                lineToRelative(2.0f, -2.0f)
+            }
+            path(fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF000000)),
+                strokeLineWidth = 2.0f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType = NonZero
+            ) {
+                moveToRelative(11.5f, 9.5f)
+                lineToRelative(2.0f, -2.0f)
+            }
+            path(fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF000000)),
+                strokeLineWidth = 2.0f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType = NonZero
+            ) {
+                moveToRelative(8.5f, 6.5f)
+                lineToRelative(2.0f, -2.0f)
+            }
+            path(fill = SolidColor(Color(0x00000000)), stroke = SolidColor(Color(0xFF000000)),
+                strokeLineWidth = 2.0f, strokeLineCap = Round, strokeLineJoin =
+                    StrokeJoin.Companion.Round, strokeLineMiter = 4.0f, pathFillType = NonZero
+            ) {
+                moveToRelative(17.5f, 15.5f)
+                lineToRelative(2.0f, -2.0f)
+            }
+        }
+            .build()
+
+        return _Ruler!!
+    }
+
+@Suppress("ObjectPropertyName")
+private var _Ruler: ImageVector? = null

--- a/app/src/main/java/com/rcmiku/ncm/dumper/ui/screen/FileDescriptionScreen.kt
+++ b/app/src/main/java/com/rcmiku/ncm/dumper/ui/screen/FileDescriptionScreen.kt
@@ -42,7 +42,7 @@ fun FileDescriptionScreen (navController: NavHostController, file: NCMFile) {
         LazyColumn(modifier = Modifier.padding(horizontal = 12.dp), contentPadding = it) {
             item {
                 Text(
-                    "File info",
+                    stringResource(R.string.file_info),
                     modifier = Modifier.padding(start = 12.dp, bottom = 12.dp),
                     style = MaterialTheme.typography.titleSmall
                 )
@@ -52,7 +52,7 @@ fun FileDescriptionScreen (navController: NavHostController, file: NCMFile) {
                 ) {
                     SettingItem(
                         imageVector = Document,
-                        title = "File Name",
+                        title = stringResource(R.string.file_name),
                         subtitle = file.name
                     )
                 }
@@ -62,7 +62,7 @@ fun FileDescriptionScreen (navController: NavHostController, file: NCMFile) {
                 ) {
                     SettingItem(
                         imageVector = Ruler,
-                        title = "File Size",
+                        title = stringResource(R.string.file_size),
                         subtitle = file.size.sizeIn()
                     )
                 }
@@ -72,7 +72,7 @@ fun FileDescriptionScreen (navController: NavHostController, file: NCMFile) {
                 ) {
                     SettingItem(
                         imageVector = Convert,
-                        title = "Convert Status",
+                        title = stringResource(R.string.file_status),
                         subtitle = when (file.taskState) {
                             TaskState.Default -> "Not converted"
                             TaskState.Success -> "Converted"
@@ -86,11 +86,8 @@ fun FileDescriptionScreen (navController: NavHostController, file: NCMFile) {
                 ) {
                     SettingItem(
                         imageVector = Folder,
-                        title = "File Path",
+                        title = stringResource(R.string.file_path),
                         subtitle = file.uri.lastPathSegment,
-                        onClick = {
-                            // Open file path in file manager
-                        }
                     )
                 }
 

--- a/app/src/main/java/com/rcmiku/ncm/dumper/ui/screen/FileDescriptionScreen.kt
+++ b/app/src/main/java/com/rcmiku/ncm/dumper/ui/screen/FileDescriptionScreen.kt
@@ -1,0 +1,101 @@
+package com.rcmiku.ncm.dumper.ui.screen
+
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.*
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalUriHandler
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
+import androidx.navigation.NavHostController
+import com.rcmiku.ncm.dumper.R
+import com.rcmiku.ncm.dumper.model.NCMFile
+import com.rcmiku.ncm.dumper.model.TaskState
+import com.rcmiku.ncm.dumper.ui.component.SettingItem
+import com.rcmiku.ncm.dumper.ui.imageVector.*
+import com.rcmiku.ncm.dumper.utils.AppUtils.sizeIn
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun FileDescriptionScreen (navController: NavHostController, file: NCMFile) {
+    val scrollBehavior = TopAppBarDefaults.pinnedScrollBehavior(rememberTopAppBarState())
+
+    Scaffold(
+        topBar = {CenterAlignedTopAppBar(
+            title = { Text(file.name) },
+            navigationIcon = {
+                IconButton(onClick = {
+                    navController.popBackStack()
+                }) {
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                        contentDescription = null
+                    )
+                }
+            },
+            scrollBehavior = scrollBehavior
+        )}) {
+        LazyColumn(modifier = Modifier.padding(horizontal = 12.dp), contentPadding = it) {
+            item {
+                Text(
+                    "File info",
+                    modifier = Modifier.padding(start = 12.dp, bottom = 12.dp),
+                    style = MaterialTheme.typography.titleSmall
+                )
+                Card(
+                    modifier = Modifier.padding(bottom = 4.dp),
+                    shape = RoundedCornerShape(16.dp, 16.dp, 8.dp, 8.dp)
+                ) {
+                    SettingItem(
+                        imageVector = Document,
+                        title = "File Name",
+                        subtitle = file.name
+                    )
+                }
+                Card(
+                    modifier = Modifier.padding(bottom = 4.dp),
+                    shape = RoundedCornerShape(8.dp, 8.dp, 8.dp, 8.dp)
+                ) {
+                    SettingItem(
+                        imageVector = Ruler,
+                        title = "File Size",
+                        subtitle = file.size.sizeIn()
+                    )
+                }
+                Card(
+                    modifier = Modifier.padding(bottom = 4.dp),
+                    shape = RoundedCornerShape(8.dp, 8.dp, 8.dp, 8.dp)
+                ) {
+                    SettingItem(
+                        imageVector = Convert,
+                        title = "Convert Status",
+                        subtitle = when (file.taskState) {
+                            TaskState.Default -> "Not converted"
+                            TaskState.Success -> "Converted"
+                            else -> file.taskState.toString()
+                        }
+                    )
+                }
+                Card(
+                    modifier = Modifier.padding(bottom = 12.dp),
+                    shape = RoundedCornerShape(8.dp, 8.dp, 16.dp, 16.dp)
+                ) {
+                    SettingItem(
+                        imageVector = Folder,
+                        title = "File Path",
+                        subtitle = file.uri.lastPathSegment,
+                        onClick = {
+                            // Open file path in file manager
+                        }
+                    )
+                }
+
+            }
+        }
+
+    }
+}

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -9,7 +9,7 @@
     <string name="select_count">已选择 %d</string>
     <string name="search">搜索</string>
     <string name="pick_folder">选择文件夹</string>
-    <string name="file_count">共 %d 个 NCM 文件</string>
+    <string name="file_count">在 %2$s 中找到 %1$d 个 NCM 文件</string>
     <string name="dump_hint">开始转换，文件保存到</string>
     <string name="basic_settings">基础</string>
     <string name="filer_dumped_file">排除已转换文件</string>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -13,4 +13,9 @@
     <string name="dump_hint">开始转换，文件保存到</string>
     <string name="basic_settings">基础</string>
     <string name="filer_dumped_file">排除已转换文件</string>
+    <string name="file_info">文件信息</string>
+    <string name="file_name">文件名</string>
+    <string name="file_size">大小</string>
+    <string name="file_status">转换状态</string>
+    <string name="file_path">文件目录</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -12,4 +12,9 @@
     <string name="dump_hint">Conversion started, files saved to</string>
     <string name="basic_settings">Basic</string>
     <string name="filer_dumped_file">Exclude Converted Files</string>
+    <string name="file_info">File info</string>
+    <string name="file_name">File name</string>
+    <string name="file_size">File size</string>
+    <string name="file_status">Convert status</string>
+    <string name="file_path">File path</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -8,7 +8,7 @@
     <string name="select_count">Selected %d</string>
     <string name="search">Search</string>
     <string name="pick_folder">Pick Folder</string>
-    <string name="file_count">Total of %d NCM files</string>
+    <string name="file_count">Found %1$d NCM files in %2$s</string>
     <string name="dump_hint">Conversion started, files saved to</string>
     <string name="basic_settings">Basic</string>
     <string name="filer_dumped_file">Exclude Converted Files</string>


### PR DESCRIPTION
if you opens a folder with no ncm in it or all of it has been dumped, then the ui will be no difference from folder not selected.

I added file description to tell the user some thing about it, I planed to add more, but it looks like other information needs some other apis, so I only add basic informations